### PR TITLE
Updated xerces and add javax.annotations dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <gt-version>21.0</gt-version>
     <pdfbox-version>2.0.7</pdfbox-version>
     <metrics-version>4.2.12</metrics-version>
+    <javax-annotation-version>1.0</javax-annotation-version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -118,7 +119,7 @@
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.4.0</version>
+        <version>2.12.2</version>
       </dependency>
       <dependency>
         <groupId>com.itextpdf</groupId>
@@ -197,6 +198,11 @@
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+      <version>${javax-annotation-version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -322,7 +328,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <!-- ======================================================= -->
@@ -336,11 +342,11 @@
           <target>1.6</target>  <!-- The -target argument for the Java compiler. -->
           <debug>true</debug>   <!-- Whether to include debugging information.   -->
           <encoding>UTF-8</encoding> <!-- The -encoding argument for the Java compiler. -->
-          <!-- 
+          <!--
                On java6 the build oom's otherwise due to the compiler accumulating
-               too many classes in the permanent generation, see GEOT-2462  
+               too many classes in the permanent generation, see GEOT-2462
           -->
-          <fork>${fork.javac}</fork> 
+          <fork>${fork.javac}</fork>
           <maxmem>${javac.maxHeapSize}</maxmem>
         </configuration>
       </plugin>
@@ -352,15 +358,15 @@
         <artifactId>wagon-webdav</artifactId>
         <version>1.0-beta-2</version>
       </extension>
-    
+
     <!--.............................................-->
     <!--       GeoSolutions (using wagon ftp)       -->
     <!--.............................................-->
-      <extension>                                  
-       <groupId>org.apache.maven.wagon</groupId>   
-       <artifactId>wagon-ftp</artifactId>           
-       <version>1.0-beta-2</version>               
-      </extension>  
+      <extension>
+       <groupId>org.apache.maven.wagon</groupId>
+       <artifactId>wagon-ftp</artifactId>
+       <version>1.0-beta-2</version>
+      </extension>
     </extensions>
   </build>
 
@@ -370,7 +376,7 @@
     <url>ftp://maven.geo-solutions.it/</url>
    </repository>
   </distributionManagement>
-  
+
 
   <!-- ================================================================== -->
   <!--     Repositories. This is where Maven looks for dependencies. The  -->
@@ -404,7 +410,7 @@
     <enabled>false</enabled>
    </releases>
   </repository>
-   
+
    <repository>
       <id>geosolutions</id>
       <name>geosolutions repository</name>
@@ -422,5 +428,5 @@
         <url>https://repo.locationtech.org/content/repositories/geogig/</url>
     </repository>
   </repositories>
-  
+
 </project>


### PR DESCRIPTION
I had compilation errors with Java 9-11 both locally and on github actions. 
I applied these changes adding : 
- `javax.annotations` lib that looks not to be included
- Updating `xercesImpl` lib to a newer one (the old is deprecated)

This seems to make tests run and the web-app properly compile. I didn't tested the application personally. 